### PR TITLE
Fixed crash when loading some logs

### DIFF
--- a/LogRest/LogMessage.cs
+++ b/LogRest/LogMessage.cs
@@ -27,7 +27,10 @@ public class LogMessage
         }
         else
         {
-            throw new Exception($"Unable to parse line: {line}");
+            Console.WriteLine($"Warning: Unable to parse line correctly: {line}. Adding default values.");
+            Date = DateTime.MinValue; // Default value
+            Level = LogLevel.Information; // Default level
+            Message = line; // Display full line in Message
         }
     }
 

--- a/LogRestTest/LogMessageTest.cs
+++ b/LogRestTest/LogMessageTest.cs
@@ -16,6 +16,15 @@ public class LogMessageTest
     }
 
     [TestMethod]
+    public void TestDateParse2()
+    {
+        var line = "System.Net.WebSockets.WebSocketException (0x80004005): The server returned status code '403' when status code '101' was expected";
+        var logMessage = new LogMessage("PAM-Web20221206.log", 1, line);
+        Assert.AreEqual(new DateTime(2022, 9, 22, 14, 45, 21, 919, DateTimeKind.Utc), logMessage.Date);
+        Assert.AreEqual(LogLevel.Information, logMessage.Level);
+    }
+
+    [TestMethod]
     public void TestLogIdParse()
     {
         var line = "2022-09-22 16:45:21.919 +02:00 [INF] Connected to hub {\"pid\": 5916, \"hub\": \"middlewarehub\"}";
@@ -24,10 +33,26 @@ public class LogMessageTest
     }
 
     [TestMethod]
+    public void TestLogIdParse2()
+    {
+        var line = "System.Net.WebSockets.WebSocketException (0x80004005): The server returned status code '403' when status code '101' was expected";
+        var logMessage = new LogMessage("PAM-Web20221206.log", 1, line);
+        Assert.AreEqual("PAM-Web20221206.log", logMessage.LogId);
+    }
+
+    [TestMethod]
     public void TestLogLevelParse()
     {
         var line = "2022-09-22 16:45:21.919 +02:00 [DBG] Connected to hub {\"pid\": 5916, \"hub\": \"middlewarehub\"}";
         var logMessage = new LogMessage("PAM-2022-09-22.log", 1, line);
+        Assert.AreEqual(LogLevel.Debug, logMessage.Level);
+    }
+
+    [TestMethod]
+    public void TestLogLevelParse2()
+    {
+        var line = "System.Net.WebSockets.WebSocketException (0x80004005): The server returned status code '403' when status code '101' was expected";
+        var logMessage = new LogMessage("PAM-Web20221206.log", 1, line);
         Assert.AreEqual(LogLevel.Debug, logMessage.Level);
     }
 
@@ -40,10 +65,26 @@ public class LogMessageTest
     }
 
     [TestMethod]
+    public void TestCriticalLogLevelParse2()
+    {
+        var line = "System.Net.WebSockets.WebSocketException (0x80004005): The server returned status code '403' when status code '101' was expected";
+        var logMessage = new LogMessage("PAM-Web20221206.log", 1, line);
+        Assert.AreEqual(LogLevel.Critical, logMessage.Level);
+    }
+
+    [TestMethod]
     public void TestWarningLogLevelParse()
     {
         var line = "2022-09-22 16:45:21.919 +02:00 [WRN] Connected to hub {\"pid\": 5916, \"hub\": \"middlewarehub\"}";
         var logMessage = new LogMessage("PAM-2022-09-22.log", 1, line);
+        Assert.AreEqual(LogLevel.Warning, logMessage.Level);
+    }
+
+    [TestMethod]
+    public void TestWarningLogLevelParse2()
+    {
+        var line = "System.Net.WebSockets.WebSocketException (0x80004005): The server returned status code '403' when status code '101' was expected";
+        var logMessage = new LogMessage("PAM-Web20221206.log", 1, line);
         Assert.AreEqual(LogLevel.Warning, logMessage.Level);
     }
 
@@ -56,6 +97,14 @@ public class LogMessageTest
     }
 
     [TestMethod]
+    public void TestNegativeTimeOffset2()
+    {
+        var line = "System.Net.WebSockets.WebSocketException (0x80004005): The server returned status code '403' when status code '101' was expected";
+        var logMessage = new LogMessage("PAM-Web20221206.log", 1, line);
+        Assert.AreEqual(new DateTime(2022, 9, 22, 18, 45, 21, 919, DateTimeKind.Utc), logMessage.Date);
+    }
+
+    [TestMethod]
     public void TestBadMessageParseThrows()
     {
         var line = "2022-13-22 16:45:21.919 -02:00 [WRN] Connected to hub {\"pid\": 5916, \"hub\": \"middlewarehub\"}";
@@ -63,10 +112,25 @@ public class LogMessageTest
     }
 
     [TestMethod]
+    public void TestBadMessageParseThrows2()
+    {
+        var line = "System.Net.WebSockets.WebSocketException (0x80004005): The server returned status code '403' when status code '101' was expected";
+        Assert.ThrowsException<Exception>(() => new LogMessage("PAM-Web20221206.log", 1, line));
+    }
+
+    [TestMethod]
     public void TestLineNumberAssigned()
     {
         var line = "2022-12-22 16:45:21.919 -02:00 [WRN] Connected to hub {\"pid\": 5916, \"hub\": \"middlewarehub\"}";
         var logMessage = new LogMessage("PAM-2022-09-22.log", 1234, line);
+        Assert.AreEqual(1234, logMessage.LineNumber);
+    }
+
+    [TestMethod]
+    public void TestLineNumberAssigned2()
+    {
+        var line = "System.Net.WebSockets.WebSocketException (0x80004005): The server returned status code '403' when status code '101' was expected";
+        var logMessage = new LogMessage("PAM-Web20221206.log", 1234, line);
         Assert.AreEqual(1234, logMessage.LineNumber);
     }
 }


### PR DESCRIPTION
Removed the exception and instead handled the incorrect parsing by still displaying the line, just adding default date/time/log level values. Added one of these problem log lines as a second test in LogMessageTest